### PR TITLE
使用http scheme替代local、embedded

### DIFF
--- a/NanUI.Demo.CodeEditor/EditorForm.cs
+++ b/NanUI.Demo.CodeEditor/EditorForm.cs
@@ -18,7 +18,7 @@ namespace NanUI.Demo.CodeEditor
 		//当然，也可以在Win7等支持DWM的系统中禁用DWM窗口绘制，如下，构造第二个参数设置为true
 		//将强制窗口使用Nanclient区域重绘。
 		public EditorForm()
-			: base("embedded://www/main.html")
+			: base("http://www/main.html")
 		{
 			InitializeComponent();
 

--- a/NanUI.Demo.CodeEditor/Program.cs
+++ b/NanUI.Demo.CodeEditor/Program.cs
@@ -18,7 +18,7 @@ namespace NanUI.Demo.CodeEditor
 			if (HtmlUILauncher.InitializeChromium())
 			{
 				//初始化成功，加载程序集内嵌的资源到运行时中
-				HtmlUILauncher.RegisterEmbeddedScheme(Resources.SchemeHelper.GetSchemeAssembley());
+				HtmlUILauncher.RegisterEmbeddedScheme(Resources.SchemeHelper.GetSchemeAssembley(), "http", "www");
 
 				//启动主窗体
 				Application.Run(new EditorForm());

--- a/NanUI.Demo.MarkdownDotNet/Program.cs
+++ b/NanUI.Demo.MarkdownDotNet/Program.cs
@@ -17,7 +17,7 @@ namespace NanUI.Demo.MarkdownDotNet
 			Application.SetCompatibleTextRenderingDefault(false);
 			if (HtmlUILauncher.InitializeChromium())
 			{
-				HtmlUILauncher.RegisterEmbeddedScheme(System.Reflection.Assembly.GetExecutingAssembly(),"res");
+				HtmlUILauncher.RegisterEmbeddedScheme(System.Reflection.Assembly.GetExecutingAssembly(), "http", "assets");
 				Application.Run(new frmMain());
 			}
 		}

--- a/NanUI.Demo.MarkdownDotNet/frmMain.cs
+++ b/NanUI.Demo.MarkdownDotNet/frmMain.cs
@@ -9,7 +9,7 @@ namespace NanUI.Demo.MarkdownDotNet
 
 
 		public frmMain()
-			: base("res://assets/main.html",true)
+			: base("http://assets/main.html",true)
 		{
 			InitializeComponent();
 

--- a/NanUI.Demo.Welcome/Program.cs
+++ b/NanUI.Demo.Welcome/Program.cs
@@ -21,8 +21,20 @@ namespace NanUI.Demo.Welcome
 				args.Settings.LogSeverity = Chromium.CfxLogSeverity.Default;
 			})))
 			{
-				//初始化成功，加载程序集内嵌的资源到运行时中
-				HtmlUILauncher.RegisterEmbeddedScheme(System.Reflection.Assembly.GetExecutingAssembly());
+				// (1) 注册本地文件资源
+				// 第1个参数指定使用http协议(schemeName)
+				// 第2个参数指定网页存放的文件夹(等价于domainName)
+				// 例如: http://www/index.html 等价于 ${当前工作路径}\www\index.html
+				// 注意: cef3官方文档强烈建议不要使用local、file等scheme，也不建议自定义scheme，
+				//        最好是使用builtin(内置)的scheme，比如: http、https。
+				//        因为自定义的scheme有些时候可能会收不到POST的数据以及其它问题!!!
+				//HtmlUILauncher.RegisterLocalScheme("http", "www");
+
+				// (2) 注册程序集内嵌资源
+				// 第1个参数指定使用http协议(schemeName)
+				// 第2个参数指定网页存放的文件夹(等价于domainName)
+				// 例如: http://www/index.html 等价于 ${程序集根目录}\www\index.html
+				HtmlUILauncher.RegisterEmbeddedScheme(System.Reflection.Assembly.GetExecutingAssembly(), "http", "www");
 
 				//启动主窗体
 				Application.Run(new frmWelcome());

--- a/NanUI.Demo.Welcome/frmAbout.cs
+++ b/NanUI.Demo.Welcome/frmAbout.cs
@@ -7,7 +7,7 @@ namespace NanUI.Demo.Welcome
 
 	{
 		public frmAbout()
-			: base("embedded://www/about.html")
+			: base("http://www/about.html")
 		{
 			InitializeComponent();
 			this.ShowInTaskbar = false;

--- a/NanUI.Demo.Welcome/frmWelcome.cs
+++ b/NanUI.Demo.Welcome/frmWelcome.cs
@@ -7,7 +7,7 @@ namespace NanUI.Demo.Welcome
 	{
 		frmAbout aboutForm = null;
 		public frmWelcome()
-			: base("embedded://www/index.html") //设定启示页面，scheme是embedded就是我们在Main里注册的当前程序集资源
+			: base("http://www/index.html") //设定启示页面，scheme是embedded就是我们在Main里注册的当前程序集资源
 		{
 			InitializeComponent();
 

--- a/NanUI.Demo.WidgetWindow/Program.cs
+++ b/NanUI.Demo.WidgetWindow/Program.cs
@@ -19,7 +19,7 @@ namespace NanUI.Demo.WidgetWindow
 
 			if (HtmlWidgetLauncher.InitializeChromium())
 			{
-				//HtmlWidgetLauncher.RegisterEmbeddedScheme(System.Reflection.Assembly.GetExecutingAssembly());
+				//HtmlWidgetLauncher.RegisterEmbeddedScheme(System.Reflection.Assembly.GetExecutingAssembly(), "http", "www");
 				Application.Run(new Form1());
 			}
 

--- a/NetDimension.NanUI/HtmlUILauncher.cs
+++ b/NetDimension.NanUI/HtmlUILauncher.cs
@@ -162,7 +162,7 @@ namespace NetDimension.NanUI
 
 				OnRegisterCustomSchemes += args =>
 				{
-					args.Registrar.AddCustomScheme("embedded", false, false, false);
+					//args.Registrar.AddCustomScheme("embedded", false, false, false);
 				};
 
 
@@ -171,7 +171,7 @@ namespace NetDimension.NanUI
 					Initialize();
 
 
-					RegisterLocalScheme();
+					//RegisterLocalScheme();
 					return true;
 
 				}
@@ -211,13 +211,18 @@ namespace NetDimension.NanUI
 
 		}
 
-		private static void RegisterLocalScheme()
+		public static void RegisterLocalScheme(string schemeName, string domainName)
 		{
-			var scheme = new LocalSchemeHandlerFactory();
+			if (string.IsNullOrEmpty(schemeName))
+            {
+                throw new ArgumentNullException("schemeName", "必须为scheme指定名称。");
+            }
+			var scheme = new LocalSchemeHandlerFactory(schemeName);
 			var gchandle = GCHandle.Alloc(scheme);
 			ChromiumStartupSettings.SchemeHandlerGCHandles.Add(gchandle);
 
-			RegisterScheme("local", null, scheme);
+			RegisterScheme(schemeName, domainName, scheme);
+			//RegisterScheme("local", null, scheme);
 		}
 
 

--- a/NetDimension.NanUI/Resource/LocalResourceHandler.cs
+++ b/NetDimension.NanUI/Resource/LocalResourceHandler.cs
@@ -45,7 +45,8 @@ namespace NetDimension.NanUI.Resource
 			var uri = new Uri(request.Url);
 
 			requestUrl = request.Url;
-			var localPath = uri.LocalPath;
+			//var localPath = uri.LocalPath;
+			var localPath = uri.Host + uri.LocalPath;
 			if (localPath.StartsWith("/"))
 				localPath = $".{localPath}";
 

--- a/NetDimension.NanUI/Resource/LocalSchemeHandlerFactory.cs
+++ b/NetDimension.NanUI/Resource/LocalSchemeHandlerFactory.cs
@@ -8,14 +8,22 @@ namespace NetDimension.NanUI.Resource
 {
 	internal class LocalSchemeHandlerFactory : CfxSchemeHandlerFactory
 	{
+		public string SchemeName
+        {
+            get;
+            private set;
+        }
+
 		internal LocalSchemeHandlerFactory()
 		{
+			this.SchemeName = schemeName;
 			this.Create += LocalSchemeHandlerFactory_Create;
 		}
 
 		private void LocalSchemeHandlerFactory_Create(object sender, Chromium.Event.CfxSchemeHandlerFactoryCreateEventArgs e)
 		{
-			if (e.SchemeName.Equals("local") && e.Browser != null)
+			if (e.SchemeName == SchemeName && e.Browser != null)
+            //if (e.SchemeName.Equals("local") && e.Browser != null)
 			{
 				var browser = HtmlUILauncher.GetBrowser(e.Browser.Identifier);
 				var handler = new LocalResourceHandler(browser);


### PR DESCRIPTION
[1]: https://bitbucket.org/chromiumembedded/cef/wiki/GeneralUsage#markdown-header-scheme-handler
**说明1：** cef3官方文档强烈建议不要自定义scheme，最好是使用内置scheme，比如: http、https，因为自定义的scheme有些时候可能会收不到POST的数据以及其它问题!!!

&nbsp;&nbsp;&nbsp;&nbsp;_Request Handling_ -> [Use the HTTP scheme instead of a custom scheme to avoid a range of potential issues.][1]

**说明2：** 主要的改动:
> 
            NanUI/Resource/LocalSchemeHandlerFactory.cs
            NanUI/Resource/LocalResourceHandler.cs
            NanUI/Resource/HtmlUILauncher.cs
**用法：**（参见Welcome/Program.cs的注释）
**（1）注册资源**
a、注册本地文件资源
> 
            // 第1个参数指定使用http协议(schemeName)
            // 第2个参数指定网页存放的文件夹(等价于domainName)
            // 例如: http://www/index.html 等价于 ${当前工作路径}\www\index.html
            HtmlUILauncher.RegisterLocalScheme("http", "www");

**b、注册程序集内嵌资源**
> 
            // 第1个参数指定使用http协议(schemeName)
            // 第2个参数指定网页存放的文件夹(等价于domainName)
            // 例如: http://www/index.html 等价于 ${程序集根目录}\www\index.html
            HtmlUILauncher.RegisterEmbeddedScheme(System.Reflection.Assembly.GetExecutingAssembly(), "http", "www");
**（2）url格式**
NanUI里一般都是从HtmlUIForm派生出一个Form来，在基类构造函数中指定url，比如Welcome/frmWelcome.cs
>
         public frmWelcome() 
                   : base("http://www/index.html")     // 使用是本地资源或程序集内嵌资源，和web开发就比较类似
                   //: base("embedded://www/index.html") // 不使用这种格式了！！！
