### PR TITLE
🕶️ 修复了KIOSK模式窗体在Hide并重新Show之后浏览器控件丢失的问题。

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ What's new in version 0.8.90
 
 Changelog
 =========
+[2022/02/25]
+在 ApplicationConfiguration 中加入了扩展方法 BeforeProcessRun。这个方法传入代理 Func<bool>，用于在 CEF 初始化前执行特定的代码，返回 true 时 NanUI 继续初始化 Chromium；返回 false 将中止当前初始化进程并关闭应用程序。
+
 [2021/12/01]
 更新版本至 0.9.90
 

--- a/src/Demo/FormiumClient/MainWindow.cs
+++ b/src/Demo/FormiumClient/MainWindow.cs
@@ -399,6 +399,7 @@ return {
     BorderlessWindowDemo borderlessStyleWindow;
     SystemBorderlessDemo systemBorderlessStyleWindow;
     LayeredWindowDemo layeredStyleWindow;
+    KioskWindowDemo kioskStyleWindow;
 
     // Add methods for windowExamples object in Formium.external object in JavaScript context.
     private void RegisterWindowStyleExampleObject()
@@ -502,9 +503,21 @@ return {
         {
             InvokeIfRequired(() =>
             {
-                var kioskStyleWindow = new KioskWindowDemo();
 
-                kioskStyleWindow.Show();
+                if (kioskStyleWindow == null || kioskStyleWindow.IsDisposed)
+                {
+                    kioskStyleWindow = new KioskWindowDemo();
+                    kioskStyleWindow.Show(this);
+
+                }
+                else
+                {
+                    if (!kioskStyleWindow.Visible)
+                    {
+                        kioskStyleWindow.Show();
+                    }
+                    kioskStyleWindow.Active();
+                }
             });
             return null;
         }));

--- a/src/Demo/FormiumClient/WindowTypes/KioskWindowDemo.cs
+++ b/src/Demo/FormiumClient/WindowTypes/KioskWindowDemo.cs
@@ -1,4 +1,4 @@
-﻿using NetDimension.NanUI;
+using NetDimension.NanUI;
 using NetDimension.NanUI.HostWindow;
 using System;
 using System.Collections.Generic;

--- a/src/NetDimension.NanUI/Formium/Formium.Browser.cs
+++ b/src/NetDimension.NanUI/Formium/Formium.Browser.cs
@@ -342,7 +342,8 @@ partial class Formium
         }
         else
         {
-            if (FormHostWindow.Visible)
+            
+            if (IsWindowVisible(HostWindowHandle))
             {
                 SetWindowPos(BrowserWindowHandle, HWND.NULL, 0, 0, rect.Width, rect.Height, SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_SHOWWINDOW | SetWindowPosFlags.SWP_NOACTIVATE);
 

--- a/src/NetDimension.NanUI/Runtime/ApplicationConfigurationBuilderExtensions.cs
+++ b/src/NetDimension.NanUI/Runtime/ApplicationConfigurationBuilderExtensions.cs
@@ -127,6 +127,27 @@ public static class ApplicationConfigurationBuilderExtensions
     }
 
     /// <summary>
+    /// Before Chromium initialization process run.
+    /// </summary>
+    /// <param name="this">The ApplicationConfigurationBuilder instance.</param>
+    /// <param name="func">A delegate that determain if the process should continue to run.</param>
+    /// <returns>Current ApplicationConfigurationBuilder instance.</returns>
+    public static ApplicationConfigurationBuilder BeforeProcessRun(this ApplicationConfigurationBuilder @this, Func<bool> func)
+    {
+        @this.Use(builder =>
+        {
+            return (runtime, props) =>
+            {
+                var retval = func.Invoke();
+
+                runtime.IsProcessShouldContinueRun = retval;
+            };
+        }, ExtensionExecutePosition.MainProcessInitilized);
+
+        return @this;
+    }
+
+    /// <summary>
     /// Use a custom resource handlder to handle the web resources.
     /// </summary>
     /// <param name="this">The ApplicationConfigurationBuilder instance.</param>

--- a/src/NetDimension.NanUI/Runtime/RuntimeContext.cs
+++ b/src/NetDimension.NanUI/Runtime/RuntimeContext.cs
@@ -112,6 +112,8 @@ public sealed class RuntimeContext
         return exitCode;
     }
 
+    internal bool IsProcessShouldContinueRun = true;
+
     internal int Initialize()
     {
         var args = Environment.GetCommandLineArgs();
@@ -122,9 +124,12 @@ public sealed class RuntimeContext
 
             var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
 
-
-
             ApplicationConfiguration.UseExtensions[(int)ExtensionExecutePosition.MainProcessInitilized]?.Invoke(this, ApplicationProperties);
+        }
+
+        if (!IsProcessShouldContinueRun)
+        {
+            return 0;
         }
 
         CefRuntime.Load(ChromiumEnvironment.LibCefDir);


### PR DESCRIPTION
- 修复了KIOSK模式窗体在Hide并重新Show之后浏览器控件丢失的问题。
- 在 ApplicationConfiguration 中加入了扩展方法 BeforeProcessRun。这个方法传入代理 Func<bool>，用于在 CEF 初始化前执行特定的代码，返回 true 时 NanUI 继续初始化 Chromium；返回 false 将中止当前初始化进程并关闭应用程序。
