### PR TITLE
为 LoadEnd 事件添加了两个参数 SkipErrorHandler 和 ErrorPageUrl

### DIFF
--- a/src/NetDimension.NanUI/Browser/BrowserProcess/Handlers/WinFormiumLoadHandler.cs
+++ b/src/NetDimension.NanUI/Browser/BrowserProcess/Handlers/WinFormiumLoadHandler.cs
@@ -25,9 +25,16 @@ internal sealed class WinFormiumLoadHandler : CefLoadHandler
 
         if (frame.IsMain)
         {
-            if (httpStatusCode >= 400 || httpStatusCode ==0)
+            if (e.SkipErrorHandler == false && ((httpStatusCode >= 400 && httpStatusCode < 500) || httpStatusCode ==0))
             {
-                frame.LoadUrl("res://formium/InternalError/index.html");
+                if(string.IsNullOrEmpty(e.ErrorPageUrl))
+                {
+                    frame.LoadUrl("res://formium/InternalError/index.html");
+                }
+                else
+                {
+                    frame.LoadUrl(e.ErrorPageUrl);
+                }
             }
             else
             {
@@ -39,8 +46,6 @@ internal sealed class WinFormiumLoadHandler : CefLoadHandler
 
     protected override void OnLoadError(CefBrowser browser, CefFrame frame, CefErrorCode errorCode, string errorText, string failedUrl)
     {
-
-
         var e = new LoadErrorEventArgs(frame, errorCode, errorText, failedUrl);
         _owner.InvokeIfRequired(() => _owner.OnLoadError(e));
     }
@@ -74,7 +79,8 @@ public sealed class LoadEndEventArgs : EventArgs
         Frame = frame;
         HttpStatusCode = httpStatusCode;
     }
-
+    public string? ErrorPageUrl { get; set; }
+    public bool SkipErrorHandler { get; set; } = false;
     public CefFrame Frame { get; }
     public int HttpStatusCode { get; }
 }

--- a/src/NetDimension.NanUI/NetDimension.NanUI.csproj
+++ b/src/NetDimension.NanUI/NetDimension.NanUI.csproj
@@ -97,15 +97,15 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="SkiaSharp" Version="2.88.0" />
-        <PackageReference Include="Vanara.PInvoke.DwmApi" Version="3.4.3" />
-        <PackageReference Include="Vanara.PInvoke.SHCore" Version="3.4.3" />
-        <PackageReference Include="Vanara.PInvoke.User32" Version="3.4.3" />
-        <PackageReference Include="Vanara.PInvoke.UxTheme" Version="3.4.3" />
-        <PackageReference Include="Vortice.Direct2D1" Version="2.1.19" />
-        <PackageReference Include="Vortice.Direct3D11" Version="2.1.19" />
-        <PackageReference Include="Vortice.DXGI" Version="2.1.19" />
-        <PackageReference Include="Vortice.Mathematics" Version="1.4.16" />
+        <PackageReference Include="SkiaSharp" Version="2.88.3" />
+        <PackageReference Include="Vanara.PInvoke.DwmApi" Version="3.4.10" />
+        <PackageReference Include="Vanara.PInvoke.SHCore" Version="3.4.10" />
+        <PackageReference Include="Vanara.PInvoke.User32" Version="3.4.10" />
+        <PackageReference Include="Vanara.PInvoke.UxTheme" Version="3.4.10" />
+        <PackageReference Include="Vortice.Direct2D1" Version="2.1.41" />
+        <PackageReference Include="Vortice.Direct3D11" Version="2.1.41" />
+        <PackageReference Include="Vortice.DXGI" Version="2.1.41" />
+        <PackageReference Include="Vortice.Mathematics" Version="1.4.19" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
为 LoadEnd 事件添加了两个参数 SkipErrorHandler 和 ErrorPageUrl。

- SkipErrorHandler : _boolean_ -- 设置为 true 时如果遇到当前页面不能访问的情况那么不调用 NanUI 内置的错误页面
- ErrorPageUrl : _string_ -- 设置一个 url，当页面不能访问时跳转到指定的 url。注意，使用 ErrorPageUrl 需要 SkipErrorHandler 设置为 false，否则本属性不生效。